### PR TITLE
Allow dotCover to optionally process assemblies that don't match the project folder name

### DIFF
--- a/modules/gulp-dotcover.js
+++ b/modules/gulp-dotcover.js
@@ -64,7 +64,7 @@ function dotCover(options) {
         var projectName = projectParts.slice(0, projectParts.length-1).join('.');
         var isBin = parts.indexOf('bin') > -1;
         var isDebugOrAgnostic = parts.indexOf('Debug') > -1 || parts.indexOf('bin') === parts.length-2;
-        var isProjectMatch = parts.indexOf(projectName) > -1;
+        var isProjectMatch = options.allowProjectAssemblyMismatch || parts.indexOf(projectName) > -1;
         var include = isBin && isDebugOrAgnostic && isProjectMatch;
         if (include) {
             assemblies.push(file);


### PR DESCRIPTION
Currently the dotCover task silently ignores assemblies whose names don't match the project folder name.
This is problematic for legacy solutions, so I needed an optional override to disable this check in cases where you know what you're doing.
Added `options.allowProjectAssemblyMismatch` (default false)
