### PR TITLE
Providing some opts to spawn should override default options, not replace them

### DIFF
--- a/modules/spawn.js
+++ b/modules/spawn.js
@@ -10,7 +10,7 @@ var defaultOptions = {
 
 var run = function(executable, args, opts) {
     args = args || [];
-    opts = opts || defaultOptions;
+    opts = Object.assign({}, defaultOptions, opts);
     var deferred = q.defer();
     var result = {
         executable: executable,


### PR DESCRIPTION
Please note that this change uses the ES6 `Object.assign()` method, so will only be compatible with Node.js v4.0+ (refer to the excellent compatibility table at https://kangax.github.io/compat-table/es6/)

I haven't seen a minimum Node.js requirement anywhere in gulp-tasks, so this may need to be introduced if you accept this as-is.

Alternatively, this change could be recoded to be backward compatible, if necessary.
