### PR TITLE
Exec module issues

### DIFF
--- a/modules/exec.js
+++ b/modules/exec.js
@@ -6,7 +6,7 @@ var log = require('./log');
 var child_process = require('child_process');
 
 var defaultOptions = {
-    cwd: process.cwd(),
+  cwd: process.cwd(),
 };
 
 var doExecFile = function(cmd, args, opts) {
@@ -84,11 +84,10 @@ var doExec = function(cmd, args, opts) {
 };
 
 var exec = function(cmd, args, opts) {
-    var deferred = q.defer();
-    args = args || [];
-    opts = opts || defaultOptions;
-    opts.maxBuffer = Number.MAX_SAFE_INTEGER;
-    return doExec(cmd, args, opts);
+  args = args || [];
+  opts = Object.assign({}, defaultOptions, opts);
+  opts.maxBuffer = Number.MAX_SAFE_INTEGER;
+  return doExec(cmd, args, opts);
 };
 
 module.exports = exec;

--- a/modules/exec.js
+++ b/modules/exec.js
@@ -65,7 +65,7 @@ var doSpawn = function(cmd, args, opts) {
   proc.on('close', function(code) {
     log.showTimeStamps();
     if (code) {
-      deferred.reject(code);
+      deferred.reject({ error: new Error('Exit code ' + code) });
     } else {
       deferred.resolve();
     }
@@ -74,7 +74,7 @@ var doSpawn = function(cmd, args, opts) {
     log.showTimeStamps();
     log.error('failed to start process');
     log.error(err);
-    deferred.reject();
+    deferred.reject({ error: err });
   });
   return deferred.promise;
 };

--- a/sonar.js
+++ b/sonar.js
@@ -3,21 +3,23 @@ var exec = requireModule('exec');
 var log = requireModule('log');
 
 var format = function(str) {
-  return str.replace('\\r', '\r').replace('\\n', '\n');
+  return (str || '').replace('\\r', '\r').replace('\\n', '\n');
 };
 
 gulp.task('sonar', ['cover-dotnet'], function(done) {
-    log.info('Running sonar');
-    exec('C:/sonar/sonar-runner-2.4/bin/sonar-runner.bat').then(function(stdout) {
-        log.info(format(stdout));
-        done();
-    }).catch(function(err) {
-        if (!err || !err.error) {
-          log.error('Sonar fails and I don\'t know why )\':');
-        } else {
-          log.error('Sonar fails: ' + err.error.code);   
-          log.error('  stdout: ' + format(err.stdout));
-          log.error('  stderr: ' + format(err.stderr));
-        }
-    });
+  log.info('Running sonar');
+  exec('C:/sonar/sonar-runner-2.4/bin/sonar-runner.bat').then(function(stdout) {
+    log.info(format(stdout));
+    done();
+  }).catch(function(err) {
+    if (!err) {
+      log.error('Sonar fails and I don\'t know why )\':');
+      done(new Error(err));
+    } else {
+      log.error('Sonar fails: ' + err.error);
+      err.stdout && log.error('  stdout: ' + format(err.stdout));
+      err.stderr && log.error('  stderr: ' + format(err.stderr));
+      done(err.error || err);
+    }
+  });
 });


### PR DESCRIPTION
This PR fixes a few inconsistencies in the exec module, and sorts out a resultant problem in the sonar task which was causing inexplicable but ignored errors.

Commit summary:
- make doSpawn failures consistent with doExecFile
- exec opts should extend defaults, not replace them
- avoid sonar error when no success stdout
- propagate sonar errors out to gulp task runner
- display failed sonar stdout + stderr even if no error available
