### PR TITLE
Some Enhancements

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,14 +7,13 @@ gulp.task('build', 'Builds all Visual Studio solutions in tree', ['nuget-restore
     '**/*.sln',
     '!**/node_modules/**/*.sln'
   ]).pipe(msbuild({
-      toolsVersion: 14.0,
-      targets: ['Clean', 'Build'],
-      configuration: 'Debug',
-      stdout: true,
-      verbosity: 'minimal',
-      errorOnFail: true,
-      architecture: 'x64'
+    toolsVersion: 14.0,
+    targets: ['Clean', 'Build'],
+    configuration: 'Debug',
+    stdout: true,
+    verbosity: 'minimal',
+    errorOnFail: true,
+    architecture: 'x64',
+    nologo: false
   }));
 });
-
-

--- a/get-local-nuget.js
+++ b/get-local-nuget.js
@@ -4,11 +4,9 @@ var gulp = requireModule('gulp-with-help'),
   verifyExe = requireModule('verify-exe');
 
 gulp.task('get-local-nuget', 'Attempts to download the latest nuget.exe to the gulp-tasks folder', function () {
-  return new Promise(function (resolve, reject) {
-    var downloader = new HttpDownloader();
-    return downloader.download(config.nugetDownloadUrl, config.localNuget).then(function (result) {
-      console.log('attempting to verify downloaded nuget.exe');
-      return verifyExe(result);
-    });
+  var downloader = new HttpDownloader();
+  return downloader.download(config.nugetDownloadUrl, config.localNuget).then(function (result) {
+    console.log('attempting to verify downloaded nuget.exe');
+    return verifyExe(result);
   });
 });

--- a/modules/exec.js
+++ b/modules/exec.js
@@ -9,7 +9,7 @@ var defaultOptions = {
   shell: true
 };
 
-var doExecFile = function (cmd, args, opts, handlers) {
+var doExecFile = function (cmd, args, opts) {
   // TODO: implement handlers for stdout, stderr
   return new Promise((resolve, reject) => {
     try {
@@ -86,7 +86,7 @@ var doSpawn = function (cmd, args, opts, handlers) {
         log.showTimeStamps();
         log.error('failed to start process');
         log.error(err);
-        deferred.reject({ error: err });
+        reject({ error: err });
       });
     } catch (e) {
       reject(e);

--- a/modules/exec.js
+++ b/modules/exec.js
@@ -6,6 +6,7 @@ var child_process = require('child_process');
 
 var defaultOptions = {
   cwd: process.cwd(),
+  shell: true
 };
 
 var doExecFile = function (cmd, args, opts, handlers) {

--- a/modules/gulp-dotnetcover.js
+++ b/modules/gulp-dotnetcover.js
@@ -34,23 +34,9 @@ function dotCover(options) {
     var regex = options.testAssemblyFilter;
     options.testAssemblyFilter = function (file) {
       return !!file.match(regex);
-    }
+    };
   }
   DEBUG = options.debug || false;
-
-  var mkdir = function (dir) {
-    var parts = dir.split("/");
-    var current = "";
-    parts.forEach(function (item) {
-      if (current) {
-        current += "/";
-      }
-      current += item;
-      if (!fs.existsSync(current)) {
-        fs.mkdirSync(current);
-      }
-    });
-  }
 
   var assemblies = [];
 
@@ -85,7 +71,7 @@ function dotCover(options) {
       runCoverageWith(this, assemblies, options);
     });
   return stream;
-};
+}
 
 function findExactExecutable(stream, options, what) {
   if (!Array.isArray(what)) {
@@ -122,7 +108,7 @@ function end(stream) {
 }
 
 function trim() {
-  var args = Array.prototype.slice.call(arguments)
+  var args = Array.prototype.slice.call(arguments);
   var source = args[0];
   var replacements = args.slice(1).join(",");
   var regex = new RegExp("^[" + replacements + "]+|[" + replacements + "]+$", "g");
@@ -134,8 +120,8 @@ function isNunit3(nunitRunner) {
 }
 
 function generateXmlOutputSwitchFor(nunitRunner, options) {
-  var outFile = options.nunitOutput;
-  return isNunit3(nunitRunner) ? "/result:" + outFile + ";format=nunit2" : "/xml=" + outFile;
+  var outFile = quoted(options.nunitOutput);
+  return isNunit3(nunitRunner) ? `/result:${outFile};format=nunit2` : `/xml=${outFile}`;
 }
 
 function generateNoShadowFor(nunitRunner) {
@@ -146,11 +132,15 @@ function generatePlatformSwitchFor(nunitRunner) {
   return isNunit3(nunitRunner) ? "/x86" : ""; // nunit 2 has separate runners; 3 has a switch
 }
 
-function updateLabelsOptionFor(nunitOptions, nunitRunner) {
+function updateLabelsOptionFor(nunitOptions) {
   if (nunitOptions.indexOf("labels:") > -1) {
     return nunitOptions; // caller already updated for new labels= syntax
   }
   return nunitOptions.replace(/\/labels/, "/labels:All");
+}
+
+function quoted(str) {
+    return `"${str.replace(/"/g, '""')}"`;
 }
 
 function runCoverageWith(stream, allAssemblies, options) {
@@ -170,11 +160,11 @@ function runCoverageWith(stream, allAssemblies, options) {
   var nunit = findNunit(stream, options);
 
   var nunitOptions = [
-    updateLabelsOptionFor(options.nunitOptions, nunit),
+    updateLabelsOptionFor(options.nunitOptions),
     generateXmlOutputSwitchFor(nunit, options),
     generateNoShadowFor(nunit),
     generatePlatformSwitchFor(nunit),
-    testAssemblies.join(" ")].join(" ");
+    testAssemblies.map(quoted).join(" ")].join(" ");
 
   var coverageToolName = grokCoverageToolNameFrom(options);
   debug(`Running tool: ${coverageToolName}`);
@@ -191,16 +181,16 @@ var commandLineOptionsGenerators = {
 var coverageSpawners = {
   dotcover: spawnDotCover,
   opencover: spawnOpenCover
-}
+};
 
 function spawnDotCover(stream, coverageToolExe, cliOptions, globalOptions) {
   const
     reportArgsFor = function (reportType) {
       log.info("creating XML args");
-      return ["report",
-        "/ReportType=" + reportType,
-        "/Source=" + globalOptions.coverageOutput,
-        "/Output=" + globalOptions.coverageReportBase + "." + reportType.toLowerCase()];
+      return ["report", 
+        `/ReportType=${reportType}`,
+        `/Source=${quoted(globalOptions.coverageOutput)}`,
+        `/Output=${quoted(globalOptions.coverageReportBase + "." + reportType.toLowerCase())}`];
     },
     xmlArgs = reportArgsFor("XML"),
     htmlArgs = reportArgsFor("HTML");
@@ -244,7 +234,7 @@ function logError(err) {
   log.error(gutil.colors.red(stringify(err)));
 }
 
-function handleCoverageFailure(stream, err, options) {
+function handleCoverageFailure(stream, err) {
   logError(" --- COVERAGE FAILS ---");
   logError(err);
   fail(stream, "coverage fails");
@@ -335,14 +325,14 @@ function getDotCoverOptionsFor(options, nunit, nunitOptions) {
   }
 
   var dotCoverOptions = ["cover",
-    `/TargetExecutable=${nunit}`,
+    `/TargetExecutable=${quoted(nunit)}`,
     `/AnalyseTargetArguments=False`,
-    `/Output=${options.coverageOutput}`,
-    `/Filters=${filters}`,
-    `/TargetArguments=${nunitOptions}`
+    `/Output=${quoted(options.coverageOutput)}`,
+    `/Filters=${quoted(filters)}`,
+    `/TargetArguments=${quoted(nunitOptions)}`
   ];
   if (scopeAssemblies.length) {
-    dotCoverOptions.push(`/Scope=${scopeAssemblies.join(";")}`);
+    dotCoverOptions.push(`/Scope=${quoted(scopeAssemblies.join(";"))}`);
   }
   log.info("running testing with coverage...");
   log.info("running dotcover with: " + dotCoverOptions.join(" "));

--- a/modules/gulp-dotnetcover.js
+++ b/modules/gulp-dotnetcover.js
@@ -187,7 +187,7 @@ function spawnDotCover(stream, coverageToolExe, cliOptions, globalOptions) {
   const
     reportArgsFor = function (reportType) {
       log.info("creating XML args");
-      return ["report", 
+      return ["report",
         `/ReportType=${reportType}`,
         `/Source=${quoted(globalOptions.coverageOutput)}`,
         `/Output=${quoted(globalOptions.coverageReportBase + "." + reportType.toLowerCase())}`];
@@ -329,6 +329,7 @@ function getDotCoverOptionsFor(options, nunit, nunitOptions) {
     `/AnalyseTargetArguments=False`,
     `/Output=${quoted(options.coverageOutput)}`,
     `/Filters=${quoted(filters)}`,
+    `/ProcessFilters=-:sqlservr.exe`,
     `/TargetArguments=${quoted(nunitOptions)}`
   ];
   if (scopeAssemblies.length) {

--- a/modules/gulp-nuget-restore.js
+++ b/modules/gulp-nuget-restore.js
@@ -1,26 +1,17 @@
 'use strict';
 var gutil = require('gulp-util'),
   es = require('event-stream'),
-  fs = require('fs'),
   q = require('q'),
   spawn = require('./spawn'),
-  exec = require('./exec'),
   log = require('./log'),
-  path = require('path'),
-  which = require('which'),
   resolveNuget = require('./resolve-nuget'),
   debug = require('debug')('gulp-nuget-restore');
 
 var PLUGIN_NAME = 'gulp-nuget-restore';
 var DEBUG = true;
 
-var CWD = process.cwd();
-function projectPathFor(path) {
-  return [CWD, path].join('/');
-}
-
 function nugetRestore(options) {
-  options = options || {}
+  options = options || {};
   DEBUG = options.debug || false;
   options.force = options.force || false;
   if (DEBUG) {
@@ -38,7 +29,7 @@ function nugetRestore(options) {
     runNugetRestoreWith(this, solutionFiles, options);
   });
   return stream;
-};
+}
 
 function fail(stream, msg) {
   stream.emit('error', new gutil.PluginError(PLUGIN_NAME, msg));
@@ -47,50 +38,24 @@ function end(stream) {
   stream.emit('end');
 }
 
-function trim() {
-  var args = Array.prototype.slice.call(arguments)
-  var source = args[0];
-  var replacements = args.slice(1).join(',');
-  var regex = new RegExp("^[" + replacements + "]+|[" + replacements + "]+$", "g");
-  return source.replace(regex, '');
-}
-
-function clearStatus() {
-  process.stdout.write('\r                \r');
-}
-
-function writeStatus(str) {
-  clearStatus();
-  process.stdout.write(str);
-}
-
-function humanSize(size) {
-  return (size / 1024 / 1024).toFixed(2) + 'mb';
-}
-
 function determineNugetCmd(nugetPath, stream) {
   try {
     var nuget = resolveNuget(nugetPath);
     log.info('Using nuget.exe from: ' + nuget);
     return nuget;
   } catch (ignore) {
-    fail(stream, `No nuget.exe resolved: ${err}`);
+    fail(stream, `No nuget.exe resolved: ${ignore}`);
   }
 }
 
 function runNuget(nugetCmd, solutions, stream) {
-  var opts = {
-    stdio: [process.stdin, process.stdout, process.stderr, 'pipe'],
-    cwd: process.cwd()
-  };
-
   debug(`nugetCmd: ${nugetCmd}`);
   var deferred = q.defer();
   var final = solutions.reduce(function (promise, item) {
     log.info('Restoring packages for: ' + item);
-    var args = ['restore', item];
+    var args = ['restore', `"${item.replace(/"/g, '""')}"`];
     return promise.then(function () {
-      return spawn(nugetCmd, args, opts).then(function () {
+      return spawn(nugetCmd, args).then(function () {
         'Packages restored for: ' + item;
       }).catch(function (err) {
         throw err;
@@ -106,15 +71,8 @@ function runNuget(nugetCmd, solutions, stream) {
   return deferred;
 }
 
-function runNugetRestoreWith(stream, solutionFiles, options, retrying) {
-  var ignored = 0;
-  var solutions = solutionFiles.map(function (file) {
-    return file.path.replace(/\\/g, '/');
-  }).reduce(function (accumulator, item) {
-    var solutionDir = path.dirname(item);
-    accumulator.push(item);
-    return accumulator;
-  }, []);
+function runNugetRestoreWith(stream, solutionFiles, options) {
+  var solutions = solutionFiles.map(file => file.path);
   if (solutions.length === 0) {
     if (solutionFiles.length == 0) {
       return fail(stream, 'No solutions defined for nuget restore');

--- a/modules/spawn.js
+++ b/modules/spawn.js
@@ -8,7 +8,8 @@ var
 
 var defaultOptions = {
   stdio: [process.stdin, process.stdout, process.stderr, 'pipe'],
-  cwd: process.cwd()
+  cwd: process.cwd(),
+  shell: true
 };
 
 var run = function (executable, args, opts) {

--- a/modules/spawn.js
+++ b/modules/spawn.js
@@ -1,10 +1,8 @@
 // use for spawning actual processes.
 // You must use exec if you want to run batch files
 var
-  q = require('q'),
   debug = require('debug')('spawn'),
-  child_process = require('child_process'),
-  debug = require('debug')('spawn-wrapper');
+  child_process = require('child_process');
 
 var defaultOptions = {
   stdio: [process.stdin, process.stdout, process.stderr, 'pipe'],
@@ -15,30 +13,30 @@ var defaultOptions = {
 var run = function (executable, args, opts) {
   args = args || [];
   opts = Object.assign({}, defaultOptions, opts);
-  var deferred = q.defer();
   var result = {
     executable: executable,
     args: args
-  } ;
+  };
 
   debug(`spawning: "${executable}" ${args.map(a => '"' + a + '"').join(' ')}`);
 
-  var child = child_process.spawn(executable, args, opts);
-  child.on('error', function (err) {
-    debug(`child error: ${err}`);
-    result.error = err;
-    deferred.reject(result);
-  })
-  child.on('close', function (code) {
-    debug(`child exits: ${code}`);
-    result.exitCode = code;
-    if (code === 0) {
-      deferred.resolve(result);
-    } else {
-      deferred.reject(result);
-    }
+  return new Promise((resolve, reject) => {
+    var child = child_process.spawn(`"${executable}"`, args, opts);
+    child.on('error', function (err) {
+      debug(`child error: ${err}`);
+      result.error = err;
+      reject(`"${[executable].concat(args).join(' ')}" failed with "${err}"`);
+    });
+    child.on('close', function (code) {
+      debug(`child exits: ${code}`);
+      result.exitCode = code;
+      if (code === 0) {
+        resolve(result);
+      } else {
+        reject(`"${[executable].concat(args).join(' ')}" failed with exit code ${code}`);
+      }
+    });
   });
-  return deferred.promise;
-}
+};
 
 module.exports = run;

--- a/modules/testutil-finder.js
+++ b/modules/testutil-finder.js
@@ -6,7 +6,8 @@ var
   debug = require("debug")("testutil-finder"),
   lsR = require("./ls-r"),
   whichLib = require("which"),
-  programFilesFolder = "C:/Program Files (x86)";
+  programFilesFolder = process.env["ProgramFiles(x86)"] || process.env["ProgramFiles"],
+  localAppDataFolder = process.env["LOCALAPPDATA"];
 
 function which(command) {
   try {
@@ -19,58 +20,78 @@ function which(command) {
 function isUnstable(folderName) {
   return folderName.indexOf("alpha") > -1 ||
     folderName.indexOf("beta") > -1;
-};
+}
 
-function finder(searchFolder, searchBin, options, searchBaseFolder) {
-  searchBaseFolder = searchBaseFolder || programFilesFolder;
-  var ignoreBetas = options.ignoreBetas === undefined ? true : options.ignoreBetas;
+/**
+ * @param {(String|String[])} [searchBaseFolders=programFilesFolder] - Base folder or array of folders.
+ * @param {String} [searchBaseSubFolder] - sub folder to add to the searchBaseFolders.
+ * @param {String} searchFolderPrefix - prefix of folders to search within each base + subfolder.
+ * @param {String} searchBin - executable filename/path to search for within  matching folders.
+ * @param {Object} [options] - optional options for the search.
+ * @param {Boolean} [options.ignoreBetas] - ignore paths with alpha or beta in the name.
+ */
+function finder(searchBaseFolders, searchBaseSubFolder, searchFolderPrefix, searchBin, options) {
+  const args = [].slice.call(arguments, 0, 5);
+  if (typeof args[args.length - 1] !== "object") {
+    args[args.length] = {};
+  }
+  searchBaseSubFolder = args.length < 5 ? undefined : args[1];
+  searchBaseFolders = [].concat(args.length < 4 ? undefined : args[0])
+    .filter(x => x)
+    .map(folder => path.join(folder, searchBaseSubFolder || ""));
+  if (!searchBaseFolders.length) {
+    searchBaseFolders = [programFilesFolder];
+  }
+  [searchFolderPrefix, searchBin, options] = args.slice(args.length - 3);
+  const ignoreBetas = options.ignoreBetas === undefined ? true : options.ignoreBetas;
 
-  if (!fs.existsSync(searchBaseFolder)) {
-    return undefined;
+  const lprefix = searchFolderPrefix.toLowerCase();
+  const runner = searchBaseFolders
+    .filter(checkExists)
+    .reduce((possibles, baseFolder) => {
+      debug("Searching: " + baseFolder);
+      return fs.readdirSync(baseFolder)
+        .reduce((acc, cur) => {
+          const folder = path.join(baseFolder, cur);
+          const lcur = cur.toLowerCase();
+          if (lcur.indexOf(lprefix) === 0) {
+            if (ignoreBetas && isUnstable(lcur)) {
+              log.notice("Ignoring unstable tool at: " + folder);
+              return acc;
+            }
+            var version = cur.match(/\d+/g).map(Number);
+            debug(`Adding possible: ${folder} = version ${version}`);
+            acc.push({
+              folder: folder,
+              version: version
+            });
+          }
+          return acc;
+        }, possibles);
+    }, [])
+    .sort((x,y) => -compareVersionArrays(x.version, y.version))
+    .map(possible => path.join(possible.folder, searchBin))
+    .find(checkExists);
+  if (runner) {
+    log.debug("Using " + runner);
   }
-  var programFolders = fs.readdirSync(searchBaseFolder);
-  var lsearch = searchFolder.toLowerCase();
-  var possibles = programFolders.reduce(function (acc, cur) {
-    var lcur = cur.toLowerCase();
-    if (lcur.indexOf(lsearch) === 0) {
-      if (ignoreBetas && isUnstable(lcur)) {
-        log.notice("Ingnoring unstable tool at: " + cur);
-        return acc;
-      }
-      acc.push(cur);
-    }
-    return acc;
-  }, []);
-  if (possibles.length === 0) {
-    throw "no possibles";
-  }
-  possibles.sort();
-  for (var i = possibles.length - 1; i > -1; i--) {
-    var runner = [searchBaseFolder, "/", possibles[i], searchBin].join("");
-    if (fs.existsSync(runner)) {
-      log.debug("Using " + runner);
-      return runner;
-    }
-  }
+  return runner;
+}
+
+function compareVersionArrays(x, y) {
+  return x.reduce((acc, cur, i) => acc || cur - y[i] || 0, 0) || x.length - y.length;
 }
 
 function findWrapper(func, name) {
-  try {
-    return func();
-  } catch (e) {
-    switch (e) {
-      case "no possibles":
-        throw "Can\"t find any installed " + name;
-      case "not found":
-        throw "Found " + name + " folder but no binaries to run )\":";
-      default:
-        throw e;
-    }
+  var found = func();
+  if (!found) {
+    throw "Can't find any installed " + name;
   }
+  return found;
 }
 
 var findInstalledNUnit3 = function () {
-  var search = [programFilesFolder, "NUnit.org", "nunit-console", "nunit3-console.exe"].join("/");
+  var search = path.join(programFilesFolder, "NUnit.org", "nunit-console", "nunit3-console.exe");
   return fs.existsSync(search) ? search : null;
 };
 
@@ -87,7 +108,7 @@ function latestNUnit(options) {
   var result = tryToFindNUnit(options);
   debug(`Using nunit runner: ${result || "NOT FOUND"}`);
   return result;
-};
+}
 
 function searchForNunit(options) {
   options = options || {};
@@ -108,8 +129,9 @@ function locateDotCover(options) {
   options = options || {};
   return initialToolSearch("dotCover.exe", "DOTCOVER") ||
     findWrapper(function () {
-      return finder("v", "/bin/dotCover.exe", options, programFilesFolder + "/JetBrains/dotCover", "dotCover");
-    });
+      return finder([programFilesFolder, localAppDataFolder], "JetBrains/Installations", "dotCover", "dotCover.exe", options)
+        || finder(programFilesFolder, "JetBrains/dotCover", "v", "Bin/dotCover.exe", options);
+    }, "dotCover");
 }
 
 function latestDotCover(options) {


### PR DESCRIPTION
Adds some missing features:
* display MSBuild logo and version at start of build - helpful when reviewing console output after a build has failed
* support for finding latest versions of dotCover (finds both dotCover installed privately and/or for all users), as well as the older versions up to v3.x
* allows dotCover and nuget restore to work when there are spaces in the project path (note that gulp-msbuild currently does not support this feature and will fail if there are spaces, so this may not be much of a feature right now)

Fixes:
* get-local-nuget was failing on first download, even though download was successful
* colour output kept breaking on Powershell and cmd under Win10 after spawning a child process (note there's still a bug in Win10 build 14393+, where it does not support the closing ANSI sequence for bold, so wherever there's bold, the current colour does not reset)
* any parameter to spawn with a quote or a backslash in it was being incorrectly quoted by node
* provides a standard workaround for the dreaded dotCover "host protection" error when covering tests against localdb

**Please note:** This changeset *may* break some parts I haven't managed to check yet, due to the change to the way parameters are passed on to spawn. I don't have a test suite right now for this, so a review would be greatly appreciated before merge :D

