### PR TITLE
OpenCover improvements

### DIFF
--- a/cover-dotnet.js
+++ b/cover-dotnet.js
@@ -11,7 +11,7 @@ gulp.task('cover-dotnet', 'Runs tests from projects matching *.Tests with DotCov
                             'AutoMapper.*',
                             'WindsorTestHelpers.*',
                             'MvcTestHelpers',
-                            'TestUtils']
+                            'TestUtils',
+                            '*.Tests.*']
              }));
 });
-

--- a/modules/gulp-dotnetcover.js
+++ b/modules/gulp-dotnetcover.js
@@ -317,6 +317,7 @@ function getOpenCoverOptionsFor(options, nunit, nunitOptions) {
     `"-output:${options.coverageReportBase}.xml"`,
     `-filter:"+[*]* ${excludeFilter}"`,  // TODO: embetterment
     `-register:user`,
+    `-mergebyhash`,
     `"-searchdirs:${getUniqueDirsFrom(options.testAssemblies)}"`
   ];
   if (failOnError) {


### PR DESCRIPTION
2 improvements to OpenCover coverage:

1. Add `-mergebyhash` command line param to merge OpenCover coverage results by module within the output coverage.xml file. This reduces some of the extra size caused by repeated module entries, when those modules are shared by several SUTs. Pretty much guaranteed to happen in a multi-project solution, given that every SUT is tested in its own bin folder.

2. Add `*.Tests.*` to standard exclude filters in `cover-dotnet.js`. This follows the general convention as intended by defaults in `gulp-dotnetcover.js`, but was lost in this case due to the extra excludes listed in cover-dotnet.